### PR TITLE
feat: make platform versions configurable via gradle.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Vaadin Gradle Skeleton Starter
 
-This project demoes the possibility of having Vaadin project in npm+webpack
-mode using Gradle. Please see the [Vaadin Gradle Plugin Page](https://github.com/vaadin/vaadin-gradle-plugin)
-for documentation.
+This project demos the possibility of having Vaadin project in npm+webpack mode using Gradle.
+Please see the [Starting a Vaadin project using Gradle](https://vaadin.com/docs/latest/guide/start/gradle) for the documentation.
 
 Prerequisites:
 * Java 8 or higher
-* node.js and npm. You can either let the Vaadin Gradle plugin to install nodejs and
-  npm/pnpm for you automatically, or you can install it to your OS:
+* node.js and npm. You can either let the Vaadin Gradle plugin to install `nodejs` and `npm/pnpm` for you automatically, or you can install it to your OS:
   * Windows: [node.js Download site](https://nodejs.org/en/download/) - use the .msi 64-bit installer
   * Linux: `sudo apt install npm`
 * Git
@@ -15,8 +13,7 @@ Prerequisites:
 
 ## Vaadin Versions
 
-* The [v14](https://github.com/vaadin/base-starter-gradle) branch (the default one)
-  contains the example app for Vaadin 14
+* The [v14](https://github.com/vaadin/base-starter-gradle) branch (the default one) contains the example app for Vaadin 14
 * See other branches for other Vaadin versions.
 
 ## Running With Gretty In Development Mode
@@ -51,9 +48,8 @@ Now you can open the [http://localhost:8080](http://localhost:8080) with your br
 
 ### Building In Production On CI
 
-Usually the CI images will not have node.js+npm available. Luckily Vaadin
-will download nodejs and npm/pnpm automatically, there is nothing
-you need to do. To build your app for production in CI, just run:
+Usually the CI images will not have node.js+npm available. Luckily Vaadin will download `nodejs` and `npm/pnpm` automatically, there is nothing you need to do.
+To build your app for production in CI, just run:
 
 ```bash
 ./gradlew clean build -Pvaadin.productionMode
@@ -63,12 +59,9 @@ you need to do. To build your app for production in CI, just run:
 
 * Download and unpack the newest [Tomcat 9](https://tomcat.apache.org/download-90.cgi).
 * Open this project in Intellij Ultimate.
-* Click "Edit Launch Configurations",
-click "Add New Configuration" (the upper-left button which looks like a plus sign + ),
-then select Tomcat Server, Local. In the Server tab, the Application Server will be missing,
-click the "Configure" button and point Intellij to the Tomcat directory.
-  * Still in the launch configuration, in the "Deployment" tab, click the upper-left + button,
-    select "Artifact" and select `base-starter-gradle.war (exploded)`.
+* Click "Edit Launch Configurations", click "Add New Configuration" (the upper-left button which looks like a plus sign `+`), then select Tomcat Server, Local.
+  In the Server tab, the Application Server will be missing, click the "Configure" button and point Intellij to the Tomcat directory.
+  * Still in the launch configuration, in the "Deployment" tab, click the upper-left + button, select "Artifact" and select `base-starter-gradle.war (exploded)`.
   * Still in the launch configuration, name the configuration "Tomcat" and click the "Ok" button.
 
 Now make sure Vaadin is configured to be run in development mode - run:
@@ -82,7 +75,7 @@ Now make sure Vaadin is configured to be run in development mode - run:
 If Tomcat fails to start with `Error during artifact deployment. See server log for details.`, please:
 * Go and vote for [IDEA-178450](https://youtrack.jetbrains.com/issue/IDEA-178450).
 * Then, kill Tomcat by pressing the red square button.
-* Then, open the launch configuration, "Deployment", remove the (exploded) war, click + and select `base-starter-gradle.war`.
+* Then, open the launch configuration, "Deployment", remove the (exploded) war, click `+` and select `base-starter-gradle.war`.
 
 ## Running/Debugging In Intellij Community With Gretty in Development Mode
 
@@ -92,13 +85,12 @@ Make sure Vaadin is configured to be run in development mode - run:
 ./gradlew clean vaadinPrepareFrontend
 ```
 
-In Intellij, open the right Gradle tab, then go into *Tasks* / *gretty*, right-click the
-*appRun* task and select Debug. Gretty will now start in debug mode, and will auto-deploy
-any changed resource or class.
+In Intellij, open the right Gradle tab, then go into *Tasks* / *gretty*, right-click the *appRun* task and select Debug.
+Gretty will now start in debug mode, and will auto-deploy any changed resource or class.
 
-There are couple of downsides:
+There are a couple of downsides:
 * Even if started in Debug mode, debugging your app won't work.
 * Pressing the red square "Stop" button will not kill the server and will leave it running.
   Instead, you have to focus the console and press any key - that will kill Gretty cleanly.
-* If Gretty says "App already running", there is something running on port 8080. See above
-  on how to kill Gretty cleanly.
+* If Gretty says "App already running", there is something running on port 8080.
+  See above on how to kill Gretty cleanly.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 plugins {
     id 'war'
     id 'org.gretty' version '3.0.3'
-    id 'com.vaadin' version '0.20.0.0.alpha3'
+    id 'com.vaadin' version '20.0.0.alpha6'
 }
 
 defaultTasks("clean", "build")
@@ -22,13 +22,15 @@ gretty {
     servletContainer = "jetty9.4"
 }
 
-// example of how to configure the Gradle Vaadin Plugin
+// The following pnpmEnable = true is not needed as pnpm is used by default,
+// this is just an example of how to configure the Gradle Vaadin Plugin:
+// for more configuraion options please see: https://vaadin.com/docs/latest/guide/start/gradle/#all-options
 vaadin {
     pnpmEnable = true
 }
 
 dependencies {
-    implementation enforcedPlatform('com.vaadin:vaadin-bom:19.0.1')
+    implementation enforcedPlatform("com.vaadin:vaadin-bom:$vaadinVersion")
 
     // Vaadin
     implementation("com.vaadin:vaadin-core")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+vaadinVersion=19.0.4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "@vaadin/vaadin-icons": "4.3.2",
       "@vaadin/vaadin-split-layout": "4.3.0",
       "@vaadin/vaadin-combo-box": "6.0.1",
-      "@vaadin/vaadin-core-shrinkwrap": "19.0.1",
+      "@vaadin/vaadin-core-shrinkwrap": "19.0.4",
       "@vaadin/vaadin-upload": "5.0.0",
       "@vaadin/vaadin-dialog": "2.5.2",
       "@vaadin/vaadin-select": "3.0.0",
@@ -69,7 +69,7 @@
       "workbox-precaching": "5.1.4",
       "webpack-manifest-plugin": "3.0.0"
     },
-    "hash": "3f86db7027473e37060a67800d511adaf594471b11c6fc6e5cae14bd15e4c31e"
+    "hash": "1298ded2b0c003a9653da7880b46711b95a040e8fcb625acc979d94b49654696"
   },
   "dependencies": {
     "lit-element": "2.3.1",
@@ -81,7 +81,7 @@
     "@vaadin/vaadin-icons": "4.3.2",
     "@vaadin/vaadin-split-layout": "4.3.0",
     "@vaadin/vaadin-combo-box": "6.0.1",
-    "@vaadin/vaadin-core-shrinkwrap": "19.0.1",
+    "@vaadin/vaadin-core-shrinkwrap": "19.0.4",
     "@vaadin/vaadin-upload": "5.0.0",
     "@vaadin/vaadin-dialog": "2.5.2",
     "@vaadin/vaadin-select": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ dependencies:
   '@vaadin/vaadin-checkbox': 3.0.0
   '@vaadin/vaadin-combo-box': 6.0.1
   '@vaadin/vaadin-context-menu': 5.0.0
-  '@vaadin/vaadin-core-shrinkwrap': 19.0.1
+  '@vaadin/vaadin-core-shrinkwrap': 19.0.4
   '@vaadin/vaadin-custom-field': 2.0.0
   '@vaadin/vaadin-date-picker': 5.0.0
   '@vaadin/vaadin-date-time-picker': 2.0.0
@@ -72,36 +72,35 @@ packages:
     dev: true
     resolution:
       integrity: sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
-  /@babel/compat-data/7.13.11:
+  /@babel/compat-data/7.13.15:
     dev: true
     resolution:
-      integrity: sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==
-  /@babel/core/7.13.10:
+      integrity: sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==
+  /@babel/core/7.13.15:
     dependencies:
       '@babel/code-frame': 7.12.13
       '@babel/generator': 7.13.9
-      '@babel/helper-compilation-targets': 7.13.10_@babel+core@7.13.10
-      '@babel/helper-module-transforms': 7.13.0
+      '@babel/helper-compilation-targets': 7.13.13_@babel+core@7.13.15
+      '@babel/helper-module-transforms': 7.13.14
       '@babel/helpers': 7.13.10
-      '@babel/parser': 7.13.11
+      '@babel/parser': 7.13.15
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/traverse': 7.13.15
+      '@babel/types': 7.13.14
       convert-source-map: 1.7.0
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.2.0
-      lodash: 4.17.21
       semver: 6.3.0
       source-map: 0.5.7
     dev: true
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
+      integrity: sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==
   /@babel/generator/7.13.9:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: true
@@ -109,21 +108,21 @@ packages:
       integrity: sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
   /@babel/helper-annotate-as-pure/7.12.13:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.12.13:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==
-  /@babel/helper-compilation-targets/7.13.10_@babel+core@7.13.10:
+  /@babel/helper-compilation-targets/7.13.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/core': 7.13.10
+      '@babel/compat-data': 7.13.15
+      '@babel/core': 7.13.15
       '@babel/helper-validator-option': 7.12.17
       browserslist: 4.16.3
       semver: 6.3.0
@@ -131,23 +130,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
-  /@babel/helper-create-class-features-plugin/7.13.11_@babel+core@7.13.10:
+      integrity: sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
+  /@babel/helper-create-class-features-plugin/7.13.11_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.0
+      '@babel/helper-member-expression-to-functions': 7.13.12
       '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
+      '@babel/helper-replace-supers': 7.13.12
       '@babel/helper-split-export-declaration': 7.12.13
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==
-  /@babel/helper-create-regexp-features-plugin/7.12.17_@babel+core@7.13.10:
+  /@babel/helper-create-regexp-features-plugin/7.12.17_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-annotate-as-pure': 7.12.13
       regexpu-core: 4.7.1
     dev: true
@@ -155,13 +154,13 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==
-  /@babel/helper-define-polyfill-provider/0.1.5_@babel+core@7.13.10:
+  /@babel/helper-define-polyfill-provider/0.2.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-compilation-targets': 7.13.10_@babel+core@7.13.10
-      '@babel/helper-module-imports': 7.12.13
+      '@babel/core': 7.13.15
+      '@babel/helper-compilation-targets': 7.13.13_@babel+core@7.13.15
+      '@babel/helper-module-imports': 7.13.12
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/traverse': 7.13.0
+      '@babel/traverse': 7.13.15
       debug: 4.3.1
       lodash.debounce: 4.0.8
       resolve: 1.20.0
@@ -170,10 +169,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0-0
     resolution:
-      integrity: sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==
+      integrity: sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==
   /@babel/helper-explode-assignable-expression/7.13.0:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==
@@ -181,52 +180,51 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.12.13
       '@babel/template': 7.12.13
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
   /@babel/helper-get-function-arity/7.12.13:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   /@babel/helper-hoist-variables/7.13.0:
     dependencies:
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/traverse': 7.13.15
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==
-  /@babel/helper-member-expression-to-functions/7.13.0:
+  /@babel/helper-member-expression-to-functions/7.13.12:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
-      integrity: sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==
-  /@babel/helper-module-imports/7.12.13:
+      integrity: sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
+  /@babel/helper-module-imports/7.13.12:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
-      integrity: sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
-  /@babel/helper-module-transforms/7.13.0:
+      integrity: sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
+  /@babel/helper-module-transforms/7.13.14:
     dependencies:
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
-      '@babel/helper-simple-access': 7.12.13
+      '@babel/helper-module-imports': 7.13.12
+      '@babel/helper-replace-supers': 7.13.12
+      '@babel/helper-simple-access': 7.13.12
       '@babel/helper-split-export-declaration': 7.12.13
       '@babel/helper-validator-identifier': 7.12.11
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-      lodash: 4.17.21
+      '@babel/traverse': 7.13.15
+      '@babel/types': 7.13.14
     dev: true
     resolution:
-      integrity: sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==
+      integrity: sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==
   /@babel/helper-optimise-call-expression/7.12.13:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
@@ -238,34 +236,34 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.12.13
       '@babel/helper-wrap-function': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==
-  /@babel/helper-replace-supers/7.13.0:
+  /@babel/helper-replace-supers/7.13.12:
     dependencies:
-      '@babel/helper-member-expression-to-functions': 7.13.0
+      '@babel/helper-member-expression-to-functions': 7.13.12
       '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/traverse': 7.13.15
+      '@babel/types': 7.13.14
     dev: true
     resolution:
-      integrity: sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==
-  /@babel/helper-simple-access/7.12.13:
+      integrity: sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
+  /@babel/helper-simple-access/7.13.12:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
-      integrity: sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==
+      integrity: sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
   /@babel/helper-split-export-declaration/7.12.13:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
@@ -281,16 +279,16 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.12.13
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/traverse': 7.13.15
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==
   /@babel/helpers/7.13.10:
     dependencies:
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/traverse': 7.13.15
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
@@ -302,142 +300,153 @@ packages:
     dev: true
     resolution:
       integrity: sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
-  /@babel/parser/7.13.11:
+  /@babel/parser/7.13.15:
     dev: true
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
-  /@babel/plugin-proposal-async-generator-functions/7.13.8_@babel+core@7.13.10:
+      integrity: sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.13.12_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
+      '@babel/plugin-proposal-optional-chaining': 7.13.12_@babel+core@7.13.15
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.13.0
+    resolution:
+      integrity: sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==
+  /@babel/plugin-proposal-async-generator-functions/7.13.15_@babel+core@7.13.15:
+    dependencies:
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
       '@babel/helper-remap-async-to-generator': 7.13.0
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.10
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==
-  /@babel/plugin-proposal-class-properties/7.13.0_@babel+core@7.13.10:
+      integrity: sha512-VapibkWzFeoa6ubXy/NgV5U2U4MVnUlvnx6wo1XhlsaTrLYWE0UFpDQsVrmn22q5CzeloqJ8gEMHSKxuee6ZdA==
+  /@babel/plugin-proposal-class-properties/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-create-class-features-plugin': 7.13.11_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-create-class-features-plugin': 7.13.11_@babel+core@7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==
-  /@babel/plugin-proposal-dynamic-import/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-proposal-dynamic-import/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.13.10
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==
-  /@babel/plugin-proposal-export-namespace-from/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-proposal-export-namespace-from/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.13.10
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-INAgtFo4OnLN3Y/j0VwAgw3HDXcDtX+C/erMvWzuV9v71r7urb6iyMXu7eM9IgLr1ElLlOkaHjJ0SbCmdOQ3Iw==
-  /@babel/plugin-proposal-json-strings/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-proposal-json-strings/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.10
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==
-  /@babel/plugin-proposal-logical-assignment-operators/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-proposal-logical-assignment-operators/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.10
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.10
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==
-  /@babel/plugin-proposal-numeric-separator/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-proposal-numeric-separator/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.10
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==
-  /@babel/plugin-proposal-object-rest-spread/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-proposal-object-rest-spread/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/core': 7.13.10
-      '@babel/helper-compilation-targets': 7.13.10_@babel+core@7.13.10
+      '@babel/compat-data': 7.13.15
+      '@babel/core': 7.13.15
+      '@babel/helper-compilation-targets': 7.13.13_@babel+core@7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-transform-parameters': 7.13.0_@babel+core@7.13.10
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-transform-parameters': 7.13.0_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==
-  /@babel/plugin-proposal-optional-catch-binding/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-proposal-optional-catch-binding/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.10
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==
-  /@babel/plugin-proposal-optional-chaining/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-proposal-optional-chaining/7.13.12_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.10
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==
-  /@babel/plugin-proposal-private-methods/7.13.0_@babel+core@7.13.10:
+      integrity: sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==
+  /@babel/plugin-proposal-private-methods/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-create-class-features-plugin': 7.13.11_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-create-class-features-plugin': 7.13.11_@babel+core@7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==
-  /@babel/plugin-proposal-unicode-property-regex/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-proposal-unicode-property-regex/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     engines:
@@ -446,127 +455,127 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.13.10:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.13.10:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.13.10:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-top-level-await/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-syntax-top-level-await/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==
-  /@babel/plugin-transform-arrow-functions/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-arrow-functions/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==
-  /@babel/plugin-transform-async-to-generator/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-async-to-generator/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-module-imports': 7.12.13
+      '@babel/core': 7.13.15
+      '@babel/helper-module-imports': 7.13.12
       '@babel/helper-plugin-utils': 7.13.0
       '@babel/helper-remap-async-to-generator': 7.13.0
     dev: true
@@ -574,32 +583,32 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==
-  /@babel/plugin-transform-block-scoped-functions/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-block-scoped-functions/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-zNyFqbc3kI/fVpqwfqkg6RvBgFpC4J18aKKMmv7KdQ/1GgREapSJAykLMVNwfRGO3BtHj3YQZl8kxCXPcVMVeg==
-  /@babel/plugin-transform-block-scoping/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-block-scoping/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==
-  /@babel/plugin-transform-classes/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-classes/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-annotate-as-pure': 7.12.13
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-optimise-call-expression': 7.12.13
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.0
+      '@babel/helper-replace-supers': 7.13.12
       '@babel/helper-split-export-declaration': 7.12.13
       globals: 11.12.0
     dev: true
@@ -607,46 +616,46 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9BtHCPUARyVH1oXGcSJD3YpsqRLROJx5ZNP6tN5vnk17N0SVf9WCtf8Nuh1CFmgByKKAIMstitKduoCmsaDK5g==
-  /@babel/plugin-transform-computed-properties/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-computed-properties/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==
-  /@babel/plugin-transform-destructuring/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-destructuring/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==
-  /@babel/plugin-transform-dotall-regex/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-dotall-regex/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==
-  /@babel/plugin-transform-duplicate-keys/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-duplicate-keys/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NfADJiiHdhLBW3pulJlJI2NB0t4cci4WTZ8FtdIuNc2+8pslXdPtRRAEWqUY+m9kNOk2eRYbTAOipAxlrOcwwQ==
-  /@babel/plugin-transform-exponentiation-operator/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-exponentiation-operator/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.12.13
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
@@ -654,18 +663,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fbUelkM1apvqez/yYx1/oICVnGo2KM5s63mhGylrmXUxK/IAXSIf87QIxVfZldWf4QsOafY6vV3bX8aMHSvNrA==
-  /@babel/plugin-transform-for-of/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-for-of/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==
-  /@babel/plugin-transform-function-name/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-function-name/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
@@ -673,28 +682,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6K7gZycG0cmIwwF7uMK/ZqeCikCGVBdyP2J5SKNCXO5EOHcqi+z7Jwf8AmyDNcBgxET8DrEtCt/mPKPyAzXyqQ==
-  /@babel/plugin-transform-literals/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-literals/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-FW+WPjSR7hiUxMcKqyNjP05tQ2kmBCdpEpZHY1ARm96tGQCCBvXKnpjILtDplUnJ/eHZ0lALLM+d2lMFSpYJrQ==
-  /@babel/plugin-transform-member-expression-literals/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-member-expression-literals/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kxLkOsg8yir4YeEPHLuO2tXP9R/gTjpuTOjshqSpELUN3ZAg2jfDnKUvzzJxObun38sw3wm4Uu69sX/zA7iRvg==
-  /@babel/plugin-transform-modules-amd/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-modules-amd/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-module-transforms': 7.13.0
+      '@babel/core': 7.13.15
+      '@babel/helper-module-transforms': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
@@ -702,23 +711,23 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==
-  /@babel/plugin-transform-modules-commonjs/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-transform-modules-commonjs/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-module-transforms': 7.13.0
+      '@babel/core': 7.13.15
+      '@babel/helper-module-transforms': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-simple-access': 7.12.13
+      '@babel/helper-simple-access': 7.13.12
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==
-  /@babel/plugin-transform-modules-systemjs/7.13.8_@babel+core@7.13.10:
+  /@babel/plugin-transform-modules-systemjs/7.13.8_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-hoist-variables': 7.13.0
-      '@babel/helper-module-transforms': 7.13.0
+      '@babel/helper-module-transforms': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
       '@babel/helper-validator-identifier': 7.12.11
       babel-plugin-dynamic-import-node: 2.3.3
@@ -727,92 +736,92 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==
-  /@babel/plugin-transform-modules-umd/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-modules-umd/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-module-transforms': 7.13.0
+      '@babel/core': 7.13.15
+      '@babel/helper-module-transforms': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-Xsm8P2hr5hAxyYblrfACXpQKdQbx4m2df9/ZZSQ8MAhsadw06+jW7s9zsSw6he+mJZXRlVMyEnVktJo4zjk1WA==
-  /@babel/plugin-transform-new-target/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-new-target/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/KY2hbLxrG5GTQ9zzZSc3xWiOy379pIETEhbtzwZcw9rvuaVV4Fqy7BYGYOWZnaoXIQYbbJ0ziXLa/sKcGCYEQ==
-  /@babel/plugin-transform-object-super/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-object-super/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.0
+      '@babel/helper-replace-supers': 7.13.12
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JzYIcj3XtYspZDV8j9ulnoMPZZnF/Cj0LUxPOjR89BdBVx+zYJI9MdMIlUZjbXDX+6YVeS6I3e8op+qQ3BYBoQ==
-  /@babel/plugin-transform-parameters/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-parameters/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==
-  /@babel/plugin-transform-property-literals/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-property-literals/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-nqVigwVan+lR+g8Fj8Exl0UQX2kymtjcWfMOYM1vTYEKujeyv2SkMgazf2qNcK7l4SDiKyTA/nHCPqL4e2zo1A==
-  /@babel/plugin-transform-regenerator/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-regenerator/7.13.15_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       regenerator-transform: 0.14.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==
-  /@babel/plugin-transform-reserved-words/7.12.13_@babel+core@7.13.10:
+      integrity: sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==
+  /@babel/plugin-transform-reserved-words/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xhUPzDXxZN1QfiOy/I5tyye+TRz6lA7z6xaT4CLOjPRMVg1ldRf0LHw0TDBpYL4vG78556WuHdyO9oi5UmzZBg==
-  /@babel/plugin-transform-shorthand-properties/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-shorthand-properties/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xpL49pqPnLtf0tVluuqvzWIgLEhuPpZzvs2yabUHSKRNlN7ScYU7aMlmavOeyXJZKgZKQRBlh8rHbKiJDraTSw==
-  /@babel/plugin-transform-spread/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-spread/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
     dev: true
@@ -820,135 +829,136 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==
-  /@babel/plugin-transform-sticky-regex/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-sticky-regex/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Jc3JSaaWT8+fr7GRvQP02fKDsYk4K/lYwWq38r/UGfaxo89ajud321NH28KRQ7xy1Ybc0VUE5Pz8psjNNDUglg==
-  /@babel/plugin-transform-template-literals/7.13.0_@babel+core@7.13.10:
+  /@babel/plugin-transform-template-literals/7.13.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==
-  /@babel/plugin-transform-typeof-symbol/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-typeof-symbol/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-eKv/LmUJpMnu4npgfvs3LiHhJua5fo/CysENxa45YCQXZwKnGCQKAg87bvoqSW1fFT+HA32l03Qxsm8ouTY3ZQ==
-  /@babel/plugin-transform-unicode-escapes/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-unicode-escapes/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0bHEkdwJ/sN/ikBHfSmOXPypN/beiGqjo+o4/5K+vxEFNPRPdImhviPakMKG4x96l85emoa0Z6cDflsdBusZbw==
-  /@babel/plugin-transform-unicode-regex/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-transform-unicode-regex/7.12.13_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-create-regexp-features-plugin': 7.12.17_@babel+core@7.13.15
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mDRzSNY7/zopwisPZ5kM9XKCfhchqIYwAKRERtEnhYscZB79VRekuRSoYbN0+KVe3y8+q1h6A4svXtP7N+UoCA==
-  /@babel/preset-env/7.13.10_@babel+core@7.13.10:
+  /@babel/preset-env/7.13.15_@babel+core@7.13.15:
     dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/core': 7.13.10
-      '@babel/helper-compilation-targets': 7.13.10_@babel+core@7.13.10
+      '@babel/compat-data': 7.13.15
+      '@babel/core': 7.13.15
+      '@babel/helper-compilation-targets': 7.13.13_@babel+core@7.13.15
       '@babel/helper-plugin-utils': 7.13.0
       '@babel/helper-validator-option': 7.12.17
-      '@babel/plugin-proposal-async-generator-functions': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-class-properties': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-proposal-dynamic-import': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-export-namespace-from': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-proposal-json-strings': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-logical-assignment-operators': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-numeric-separator': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-proposal-object-rest-spread': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-optional-catch-binding': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-optional-chaining': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-proposal-private-methods': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-proposal-unicode-property-regex': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.10
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.10
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.10
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-top-level-await': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-arrow-functions': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-async-to-generator': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-block-scoped-functions': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-block-scoping': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-classes': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-computed-properties': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-destructuring': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-dotall-regex': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-duplicate-keys': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-exponentiation-operator': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-for-of': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-function-name': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-literals': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-member-expression-literals': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-modules-amd': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-modules-commonjs': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-transform-modules-systemjs': 7.13.8_@babel+core@7.13.10
-      '@babel/plugin-transform-modules-umd': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-new-target': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-object-super': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-parameters': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-property-literals': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-regenerator': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-reserved-words': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-shorthand-properties': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-spread': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-sticky-regex': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-template-literals': 7.13.0_@babel+core@7.13.10
-      '@babel/plugin-transform-typeof-symbol': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-unicode-escapes': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-unicode-regex': 7.12.13_@babel+core@7.13.10
-      '@babel/preset-modules': 0.1.4_@babel+core@7.13.10
-      '@babel/types': 7.13.0
-      babel-plugin-polyfill-corejs2: 0.1.10_@babel+core@7.13.10
-      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.13.10
-      babel-plugin-polyfill-regenerator: 0.1.6_@babel+core@7.13.10
-      core-js-compat: 3.9.1
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.13.12_@babel+core@7.13.15
+      '@babel/plugin-proposal-async-generator-functions': 7.13.15_@babel+core@7.13.15
+      '@babel/plugin-proposal-class-properties': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-proposal-dynamic-import': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-proposal-export-namespace-from': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-proposal-json-strings': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-proposal-logical-assignment-operators': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-proposal-numeric-separator': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-proposal-object-rest-spread': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-proposal-optional-catch-binding': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-proposal-optional-chaining': 7.13.12_@babel+core@7.13.15
+      '@babel/plugin-proposal-private-methods': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-proposal-unicode-property-regex': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.15
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.15
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.15
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.15
+      '@babel/plugin-syntax-top-level-await': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-arrow-functions': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-async-to-generator': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-block-scoped-functions': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-block-scoping': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-classes': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-computed-properties': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-destructuring': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-dotall-regex': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-duplicate-keys': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-exponentiation-operator': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-for-of': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-function-name': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-literals': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-member-expression-literals': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-modules-amd': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-modules-commonjs': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-transform-modules-systemjs': 7.13.8_@babel+core@7.13.15
+      '@babel/plugin-transform-modules-umd': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-new-target': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-object-super': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-parameters': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-property-literals': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-regenerator': 7.13.15_@babel+core@7.13.15
+      '@babel/plugin-transform-reserved-words': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-shorthand-properties': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-spread': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-sticky-regex': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-template-literals': 7.13.0_@babel+core@7.13.15
+      '@babel/plugin-transform-typeof-symbol': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-unicode-escapes': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-unicode-regex': 7.12.13_@babel+core@7.13.15
+      '@babel/preset-modules': 0.1.4_@babel+core@7.13.15
+      '@babel/types': 7.13.14
+      babel-plugin-polyfill-corejs2: 0.2.0_@babel+core@7.13.15
+      babel-plugin-polyfill-corejs3: 0.2.0_@babel+core@7.13.15
+      babel-plugin-polyfill-regenerator: 0.2.0_@babel+core@7.13.15
+      core-js-compat: 3.10.1
       semver: 6.3.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==
-  /@babel/preset-modules/0.1.4_@babel+core@7.13.10:
+      integrity: sha512-D4JAPMXcxk69PKe81jRJ21/fP/uYdcTZ3hJDF5QX2HSI9bBxxYw/dumdR6dGumhjxlprHPE4XWoPaqzZUVy2MA==
+  /@babel/preset-modules/0.1.4_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.15
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-transform-dotall-regex': 7.12.13_@babel+core@7.13.10
-      '@babel/types': 7.13.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.12.13_@babel+core@7.13.15
+      '@babel/plugin-transform-dotall-regex': 7.12.13_@babel+core@7.13.15
+      '@babel/types': 7.13.14
       esutils: 2.0.3
     dev: true
     peerDependencies:
@@ -964,33 +974,32 @@ packages:
   /@babel/template/7.12.13:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/parser': 7.13.11
-      '@babel/types': 7.13.0
+      '@babel/parser': 7.13.15
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
-  /@babel/traverse/7.13.0:
+  /@babel/traverse/7.13.15:
     dependencies:
       '@babel/code-frame': 7.12.13
       '@babel/generator': 7.13.9
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.13.11
-      '@babel/types': 7.13.0
+      '@babel/parser': 7.13.15
+      '@babel/types': 7.13.14
       debug: 4.3.1
       globals: 11.12.0
-      lodash: 4.17.21
     dev: true
     resolution:
-      integrity: sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
-  /@babel/types/7.13.0:
+      integrity: sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==
+  /@babel/types/7.13.14:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
       lodash: 4.17.21
       to-fast-properties: 2.0.0
     dev: true
     resolution:
-      integrity: sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
+      integrity: sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
   /@hapi/address/2.1.4:
     deprecated: Moved to 'npm install @sideway/address'
     dev: true
@@ -1134,7 +1143,7 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==
-  /@rollup/plugin-replace/2.4.1_rollup@1.32.1:
+  /@rollup/plugin-replace/2.4.2_rollup@1.32.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@1.32.1
       magic-string: 0.25.7
@@ -1143,12 +1152,12 @@ packages:
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
-      integrity: sha512-XwC1oK5rrtRJ0tn1ioLHS6OV5JTluJF7QE1J/q1hN3bquwjnVxjtMyY9iCnoyH9DQbf92CxajB3o98wZbP3oAQ==
+      integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==
   /@rollup/pluginutils/3.1.0_rollup@1.32.1:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
-      picomatch: 2.2.2
+      picomatch: 2.2.3
       rollup: 1.32.1
     dev: true
     engines:
@@ -1172,14 +1181,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-  /@types/estree/0.0.46:
+  /@types/estree/0.0.47:
     dev: true
     resolution:
-      integrity: sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
+      integrity: sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
   /@types/glob/7.1.3:
     dependencies:
-      '@types/minimatch': 3.0.3
-      '@types/node': 14.14.35
+      '@types/minimatch': 3.0.4
+      '@types/node': 14.14.37
     dev: true
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
@@ -1191,17 +1200,17 @@ packages:
     dev: true
     resolution:
       integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
-  /@types/minimatch/3.0.3:
+  /@types/minimatch/3.0.4:
     dev: true
     resolution:
-      integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
-  /@types/node/14.14.35:
+      integrity: sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
+  /@types/node/14.14.37:
     dev: true
     resolution:
-      integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+      integrity: sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: true
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
@@ -1209,10 +1218,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
-  /@types/tapable/1.0.6:
+  /@types/tapable/1.0.7:
     dev: true
     resolution:
-      integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+      integrity: sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
   /@types/uglify-js/3.13.0:
     dependencies:
       source-map: 0.6.1
@@ -1225,23 +1234,23 @@ packages:
       integrity: sha512-gHUHI6pJaANIO2r6WcbT7+WMgbL9GZooR4tWpuBOETpDIqFNxwaJluE+6rj6VGYe8k6OkfhbHz2Fkm8kl06Igw==
   /@types/webpack-sources/2.1.0:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       '@types/source-list-map': 0.1.2
       source-map: 0.7.3
     dev: true
     resolution:
       integrity: sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==
-  /@types/webpack/4.41.26:
+  /@types/webpack/4.41.27:
     dependencies:
       '@types/anymatch': 1.3.1
-      '@types/node': 14.14.35
-      '@types/tapable': 1.0.6
+      '@types/node': 14.14.37
+      '@types/tapable': 1.0.7
       '@types/uglify-js': 3.13.0
       '@types/webpack-sources': 2.1.0
       source-map: 0.6.1
     dev: true
     resolution:
-      integrity: sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==
+      integrity: sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==
   /@vaadin/router/1.7.4:
     dependencies:
       '@vaadin/vaadin-usage-statistics': 2.1.0
@@ -1345,7 +1354,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oGsNaWbM6RisY1LkyWYtwnw+DtSRSpkFDbemEOtkYezj+Hhsd9+07LqILaUU4pB0zPaRq+uq+2tKba/TL3t23g==
-  /@vaadin/vaadin-core-shrinkwrap/19.0.1:
+  /@vaadin/vaadin-core-shrinkwrap/19.0.4:
     dependencies:
       '@polymer/iron-a11y-announcer': 3.0.2
       '@polymer/iron-a11y-keys-behavior': 3.0.1
@@ -1401,7 +1410,7 @@ packages:
       '@webcomponents/shadycss': 1.9.6
     dev: false
     resolution:
-      integrity: sha512-oaKRexbHcI/bfDTrHCnWzocBLeQ0fAoMx2R+mbswRwnv7Izdh09twDsDVh2nAByGggE7qa2XBjsRnEj7cTn+Jg==
+      integrity: sha512-f8rPChgwKlzBIYW0eSLleYQb4NHPXlu1AT0vyx7dVUXkcHU4KwtxoxIqJdzjKPMKhrFkyBucZH0MVM1RnR+NrQ==
   /@vaadin/vaadin-custom-field/2.0.0:
     dependencies:
       '@polymer/polymer': 3.2.0
@@ -1864,7 +1873,7 @@ packages:
       integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
   /accepts/1.3.7:
     dependencies:
-      mime-types: 2.1.29
+      mime-types: 2.1.30
       negotiator: 0.6.2
     dev: true
     engines:
@@ -1958,15 +1967,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  /anymatch/3.1.1:
+  /anymatch/3.1.2:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.2.2
+      picomatch: 2.2.3
     dev: true
     engines:
       node: '>= 8'
     resolution:
-      integrity: sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+      integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
   /aproba/1.2.0:
     dev: true
     resolution:
@@ -2232,36 +2241,36 @@ packages:
     dev: true
     resolution:
       integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
-  /babel-plugin-polyfill-corejs2/0.1.10_@babel+core@7.13.10:
+  /babel-plugin-polyfill-corejs2/0.2.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/core': 7.13.10
-      '@babel/helper-define-polyfill-provider': 0.1.5_@babel+core@7.13.10
+      '@babel/compat-data': 7.13.15
+      '@babel/core': 7.13.15
+      '@babel/helper-define-polyfill-provider': 0.2.0_@babel+core@7.13.15
       semver: 6.3.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==
-  /babel-plugin-polyfill-corejs3/0.1.7_@babel+core@7.13.10:
+      integrity: sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==
+  /babel-plugin-polyfill-corejs3/0.2.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-define-polyfill-provider': 0.1.5_@babel+core@7.13.10
-      core-js-compat: 3.9.1
+      '@babel/core': 7.13.15
+      '@babel/helper-define-polyfill-provider': 0.2.0_@babel+core@7.13.15
+      core-js-compat: 3.10.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==
-  /babel-plugin-polyfill-regenerator/0.1.6_@babel+core@7.13.10:
+      integrity: sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==
+  /babel-plugin-polyfill-regenerator/0.2.0_@babel+core@7.13.15:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-define-polyfill-provider': 0.1.5_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/helper-define-polyfill-provider': 0.2.0_@babel+core@7.13.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==
+      integrity: sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==
   /babel-plugin-syntax-async-functions/6.13.0:
     dev: true
     resolution:
@@ -2574,10 +2583,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
-  /balanced-match/1.0.0:
+  /balanced-match/1.0.2:
     dev: true
     resolution:
-      integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+      integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
   /base/0.11.2:
     dependencies:
       cache-base: 1.0.1
@@ -2656,7 +2665,7 @@ packages:
       integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=
   /brace-expansion/1.1.11:
     dependencies:
-      balanced-match: 1.0.0
+      balanced-match: 1.0.2
       concat-map: 0.0.1
     dev: true
     resolution:
@@ -2668,7 +2677,7 @@ packages:
       extend-shallow: 2.0.1
       fill-range: 4.0.0
       isobject: 3.0.1
-      repeat-element: 1.1.3
+      repeat-element: 1.1.4
       snapdragon: 0.8.2
       snapdragon-node: 2.1.1
       split-string: 3.1.0
@@ -2747,17 +2756,17 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30001202
-      electron-to-chromium: 1.3.691
+      caniuse-lite: 1.0.30001208
+      electron-to-chromium: 1.3.712
     dev: true
     hasBin: true
     resolution:
       integrity: sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
   /browserslist/4.16.3:
     dependencies:
-      caniuse-lite: 1.0.30001202
+      caniuse-lite: 1.0.30001208
       colorette: 1.2.2
-      electron-to-chromium: 1.3.691
+      electron-to-chromium: 1.3.712
       escalade: 3.1.1
       node-releases: 1.1.71
     dev: true
@@ -2829,13 +2838,13 @@ packages:
       move-concurrently: 1.0.1
       promise-inflight: 1.0.1
       rimraf: 2.7.1
-      ssri: 6.0.1
+      ssri: 6.0.2
       unique-filename: 1.1.1
-      y18n: 4.0.1
+      y18n: 4.0.3
     dev: true
     resolution:
       integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==
-  /cacache/15.0.5:
+  /cacache/15.0.6:
     dependencies:
       '@npmcli/move-file': 1.1.2
       chownr: 2.0.0
@@ -2858,7 +2867,7 @@ packages:
     engines:
       node: '>= 10'
     resolution:
-      integrity: sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
+      integrity: sha512-g1WYDMct/jzW+JdWEyjaX2zoBkZ6ZT9VpOyp2I/VMtDsNLffNat3kqPFfi1eDRSK9/SuKGyORDHcQMcPF8sQ/w==
   /cache-base/1.0.1:
     dependencies:
       collection-visit: 1.0.0
@@ -2885,7 +2894,7 @@ packages:
   /camel-case/4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.1.0
+      tslib: 2.2.0
     dev: true
     resolution:
       integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
@@ -2901,10 +2910,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
-  /caniuse-lite/1.0.30001202:
+  /caniuse-lite/1.0.30001208:
     dev: true
     resolution:
-      integrity: sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==
+      integrity: sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
   /chalk/1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -2929,7 +2938,7 @@ packages:
       integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   /chokidar/3.5.1:
     dependencies:
-      anymatch: 3.1.1
+      anymatch: 3.1.2
       braces: 3.0.2
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
@@ -2953,14 +2962,12 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
-  /chrome-trace-event/1.0.2:
-    dependencies:
-      tslib: 1.14.1
+  /chrome-trace-event/1.0.3:
     dev: true
     engines:
       node: '>=6.0'
     resolution:
-      integrity: sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
+      integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
   /cipher-base/1.0.4:
     dependencies:
       inherits: 2.0.4
@@ -3050,7 +3057,7 @@ packages:
       integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
   /compressible/2.0.18:
     dependencies:
-      mime-db: 1.46.0
+      mime-db: 1.47.0
     dev: true
     engines:
       node: '>= 0.6'
@@ -3058,7 +3065,7 @@ packages:
       integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
   /compression-webpack-plugin/4.0.1_webpack@4.46.0:
     dependencies:
-      cacache: 15.0.5
+      cacache: 15.0.6
       find-cache-dir: 3.3.1
       schema-utils: 2.7.1
       serialize-javascript: 4.0.0
@@ -3165,13 +3172,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-  /core-js-compat/3.9.1:
+  /core-js-compat/3.10.1:
     dependencies:
       browserslist: 4.16.3
       semver: 7.0.0
     dev: true
     resolution:
-      integrity: sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==
+      integrity: sha512-ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==
   /core-js/2.6.12:
     deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     dev: true
@@ -3231,7 +3238,7 @@ packages:
       create-hmac: 1.1.7
       diffie-hellman: 5.0.3
       inherits: 2.0.4
-      pbkdf2: 3.1.1
+      pbkdf2: 3.1.2
       public-encrypt: 4.0.3
       randombytes: 2.1.0
       randomfill: 1.0.4
@@ -3258,7 +3265,7 @@ packages:
       postcss-modules-values: 3.0.0
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.1
-      semver: 7.3.4
+      semver: 7.3.5
       webpack: 4.46.0_webpack-cli@3.3.11
     dev: true
     engines:
@@ -3479,7 +3486,7 @@ packages:
       integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   /dom-serializer/0.2.2:
     dependencies:
-      domelementtype: 2.1.0
+      domelementtype: 2.2.0
       entities: 2.2.0
     dev: true
     resolution:
@@ -3495,10 +3502,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
-  /domelementtype/2.1.0:
+  /domelementtype/2.2.0:
     dev: true
     resolution:
-      integrity: sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
+      integrity: sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
   /domhandler/2.4.2:
     dependencies:
       domelementtype: 1.3.1
@@ -3515,7 +3522,7 @@ packages:
   /dot-case/3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.1.0
+      tslib: 2.2.0
     dev: true
     resolution:
       integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
@@ -3539,10 +3546,10 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
-  /electron-to-chromium/1.3.691:
+  /electron-to-chromium/1.3.712:
     dev: true
     resolution:
-      integrity: sha512-ZqiO69KImmOGCyoH0icQPU3SndJiW93juEvf63gQngyhODO6SpQIPMTOHldtCs5DS5GMKvAkquk230E2zt2vpw==
+      integrity: sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw==
   /elliptic/6.5.4:
     dependencies:
       bn.js: 4.12.0
@@ -3635,7 +3642,7 @@ packages:
       object.assign: 4.1.2
       string.prototype.trimend: 1.0.4
       string.prototype.trimstart: 1.0.4
-      unbox-primitive: 1.0.0
+      unbox-primitive: 1.0.1
     dev: true
     engines:
       node: '>= 0.4'
@@ -4361,8 +4368,8 @@ packages:
   /html-webpack-plugin/4.5.1_webpack@4.46.0:
     dependencies:
       '@types/html-minifier-terser': 5.1.1
-      '@types/tapable': 1.0.6
-      '@types/webpack': 4.41.26
+      '@types/tapable': 1.0.7
+      '@types/webpack': 4.41.27
       html-minifier-terser: 5.1.1
       loader-utils: 1.2.3
       lodash: 4.17.21
@@ -5080,7 +5087,7 @@ packages:
       integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   /lower-case/2.0.2:
     dependencies:
-      tslib: 2.1.0
+      tslib: 2.2.0
     dev: true
     resolution:
       integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
@@ -5217,15 +5224,15 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
-  /micromatch/4.0.2:
+  /micromatch/4.0.4:
     dependencies:
       braces: 3.0.2
-      picomatch: 2.2.2
+      picomatch: 2.2.3
     dev: true
     engines:
-      node: '>=8'
+      node: '>=8.6'
     resolution:
-      integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+      integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
   /miller-rabin/4.0.1:
     dependencies:
       bn.js: 4.12.0
@@ -5234,20 +5241,20 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
-  /mime-db/1.46.0:
+  /mime-db/1.47.0:
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
-  /mime-types/2.1.29:
+      integrity: sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
+  /mime-types/2.1.30:
     dependencies:
-      mime-db: 1.46.0
+      mime-db: 1.47.0
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
+      integrity: sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   /mime/1.6.0:
     dev: true
     engines:
@@ -5441,7 +5448,7 @@ packages:
   /no-case/3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.1.0
+      tslib: 2.2.0
     dev: true
     resolution:
       integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
@@ -5724,7 +5731,7 @@ packages:
   /param-case/3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.1.0
+      tslib: 2.2.0
     dev: true
     resolution:
       integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
@@ -5733,7 +5740,7 @@ packages:
       asn1.js: 5.4.1
       browserify-aes: 1.2.0
       evp_bytestokey: 1.0.3
-      pbkdf2: 3.1.1
+      pbkdf2: 3.1.2
       safe-buffer: 5.2.1
     dev: true
     resolution:
@@ -5753,7 +5760,7 @@ packages:
   /pascal-case/3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.1.0
+      tslib: 2.2.0
     dev: true
     resolution:
       integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
@@ -5807,7 +5814,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
-  /pbkdf2/3.1.1:
+  /pbkdf2/3.1.2:
     dependencies:
       create-hash: 1.2.0
       create-hmac: 1.1.7
@@ -5818,13 +5825,13 @@ packages:
     engines:
       node: '>=0.12'
     resolution:
-      integrity: sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
-  /picomatch/2.2.2:
+      integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
+  /picomatch/2.2.3:
     dev: true
     engines:
       node: '>=8.6'
     resolution:
-      integrity: sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+      integrity: sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
   /pify/2.3.0:
     dev: true
     engines:
@@ -6112,7 +6119,7 @@ packages:
       integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   /readdirp/3.5.0:
     dependencies:
-      picomatch: 2.2.2
+      picomatch: 2.2.3
     dev: true
     engines:
       node: '>=8.10.0'
@@ -6183,7 +6190,7 @@ packages:
       regenerate: 1.4.2
       regenerate-unicode-properties: 8.2.0
       regjsgen: 0.5.2
-      regjsparser: 0.6.7
+      regjsparser: 0.6.9
       unicode-match-property-ecmascript: 1.0.4
       unicode-match-property-value-ecmascript: 1.2.0
     dev: true
@@ -6206,13 +6213,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=
-  /regjsparser/0.6.7:
+  /regjsparser/0.6.9:
     dependencies:
       jsesc: 0.5.0
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==
+      integrity: sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==
   /relateurl/0.2.7:
     dev: true
     engines:
@@ -6229,12 +6236,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==
-  /repeat-element/1.1.3:
+  /repeat-element/1.1.4:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+      integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
   /repeat-string/1.6.1:
     dev: true
     engines:
@@ -6331,10 +6338,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  /rollup-plugin-babel/4.4.0_995c6807146f1052b5e3e40fc7e397c2:
+  /rollup-plugin-babel/4.4.0_874dc89e760dd89411bff7fe30d4d8f1:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-module-imports': 7.12.13
+      '@babel/core': 7.13.15
+      '@babel/helper-module-imports': 7.13.12
       rollup: 1.32.1
       rollup-pluginutils: 2.8.2
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-babel.
@@ -6365,8 +6372,8 @@ packages:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   /rollup/1.32.1:
     dependencies:
-      '@types/estree': 0.0.46
-      '@types/node': 14.14.35
+      '@types/estree': 0.0.47
+      '@types/node': 14.14.37
       acorn: 7.4.1
     dev: true
     hasBin: true
@@ -6460,7 +6467,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
-  /semver/7.3.4:
+  /semver/7.3.5:
     dependencies:
       lru-cache: 6.0.0
     dev: true
@@ -6468,7 +6475,7 @@ packages:
       node: '>=10'
     hasBin: true
     resolution:
-      integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+      integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   /send/0.17.1:
     dependencies:
       debug: 2.6.9
@@ -6502,7 +6509,7 @@ packages:
       debug: 2.6.9
       escape-html: 1.0.3
       http-errors: 1.6.3
-      mime-types: 2.1.29
+      mime-types: 2.1.30
       parseurl: 1.3.3
     dev: true
     engines:
@@ -6719,12 +6726,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
-  /ssri/6.0.1:
+  /ssri/6.0.2:
     dependencies:
       figgy-pudding: 3.5.2
     dev: true
     resolution:
-      integrity: sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+      integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   /ssri/8.0.1:
     dependencies:
       minipass: 3.1.3
@@ -7034,7 +7041,7 @@ packages:
       chalk: 2.4.2
       enhanced-resolve: 4.5.0
       loader-utils: 1.2.3
-      micromatch: 4.0.2
+      micromatch: 4.0.4
       semver: 6.3.0
       typescript: 4.0.3
       webpack: 4.46.0_webpack-cli@3.3.11
@@ -7046,14 +7053,10 @@ packages:
       webpack: '*'
     resolution:
       integrity: sha512-UIivVfGVJDdwwjgSrbtcL9Nf10c1BWnL1mxAQUVcnhNIn/P9W3nP5v60Z0aBMtc7ZrE11lMmU6+5jSgAXmGaYw==
-  /tslib/1.14.1:
+  /tslib/2.2.0:
     dev: true
     resolution:
-      integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-  /tslib/2.1.0:
-    dev: true
-    resolution:
-      integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+      integrity: sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
   /tty-browserify/0.0.0:
     dev: true
     resolution:
@@ -7067,7 +7070,7 @@ packages:
   /type-is/1.6.18:
     dependencies:
       media-typer: 0.3.0
-      mime-types: 2.1.29
+      mime-types: 2.1.30
     dev: true
     engines:
       node: '>= 0.6'
@@ -7084,7 +7087,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
-  /unbox-primitive/1.0.0:
+  /unbox-primitive/1.0.1:
     dependencies:
       function-bind: 1.1.1
       has-bigints: 1.0.1
@@ -7092,7 +7095,7 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
     resolution:
-      integrity: sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==
+      integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
   /unicode-canonical-property-names-ecmascript/1.0.4:
     dev: true
     engines:
@@ -7432,7 +7435,7 @@ packages:
       acorn: 6.4.2
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
-      chrome-trace-event: 1.0.2
+      chrome-trace-event: 1.0.3
       enhanced-resolve: 4.5.0
       eslint-scope: 4.0.3
       json-parse-better-errors: 1.0.2
@@ -7522,12 +7525,12 @@ packages:
       integrity: sha512-HTyTWkqXvHRuqY73XrwvXPud/FN6x3ROzkfFPsRjtw/kGZuZkPzfeH531qdUGfhtwjmtO/ZzXcWErqVzJNdXaA==
   /workbox-build/5.1.4:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/preset-env': 7.13.10_@babel+core@7.13.10
+      '@babel/core': 7.13.15
+      '@babel/preset-env': 7.13.15_@babel+core@7.13.15
       '@babel/runtime': 7.13.10
       '@hapi/joi': 15.1.1
       '@rollup/plugin-node-resolve': 7.1.3_rollup@1.32.1
-      '@rollup/plugin-replace': 2.4.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.4.2_rollup@1.32.1
       '@surma/rollup-plugin-off-main-thread': 1.4.2
       common-tags: 1.8.0
       fast-json-stable-stringify: 2.1.0
@@ -7536,7 +7539,7 @@ packages:
       lodash.template: 4.5.0
       pretty-bytes: 5.6.0
       rollup: 1.32.1
-      rollup-plugin-babel: 4.4.0_995c6807146f1052b5e3e40fc7e397c2
+      rollup-plugin-babel: 4.4.0_874dc89e760dd89411bff7fe30d4d8f1
       rollup-plugin-terser: 5.3.1_rollup@1.32.1
       source-map: 0.7.3
       source-map-url: 0.4.1
@@ -7684,10 +7687,10 @@ packages:
       node: '>=0.4'
     resolution:
       integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
-  /y18n/4.0.1:
+  /y18n/4.0.3:
     dev: true
     resolution:
-      integrity: sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+      integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
   /yallist/3.1.1:
     dev: true
     resolution:
@@ -7714,7 +7717,7 @@ packages:
       set-blocking: 2.0.0
       string-width: 3.1.0
       which-module: 2.0.0
-      y18n: 4.0.1
+      y18n: 4.0.3
       yargs-parser: 13.1.2
     dev: true
     resolution:
@@ -7729,7 +7732,7 @@ packages:
       set-blocking: 2.0.0
       string-width: 3.1.0
       which-module: 2.0.0
-      y18n: 4.0.1
+      y18n: 4.0.3
       yargs-parser: 13.1.2
     dev: true
     resolution:
@@ -7749,7 +7752,7 @@ specifiers:
   '@vaadin/vaadin-checkbox': 3.0.0
   '@vaadin/vaadin-combo-box': 6.0.1
   '@vaadin/vaadin-context-menu': 5.0.0
-  '@vaadin/vaadin-core-shrinkwrap': 19.0.1
+  '@vaadin/vaadin-core-shrinkwrap': 19.0.4
   '@vaadin/vaadin-custom-field': 2.0.0
   '@vaadin/vaadin-date-picker': 5.0.0
   '@vaadin/vaadin-date-time-picker': 2.0.0


### PR DESCRIPTION
To enable Platform release script bump the
platform version in the starter project,
vaadinVersion property is used from
gradle.properties.

Before vaadin 20.0.0 released, we update the
latest version of gradle-plugin manually.
After that, Platform and gradle-plugin versions
should be the same and would be configured
via the vaadinVersion property.

README.md contents also updated.