### PR TITLE
chore: build by default for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Then you can check results in the `build/reports/tests/integrationTest/index.htm
 Simply run the following command in this repo:
 
 ```bash
-./gradlew clean build -Pvaadin.productionMode
+./gradlew clean build
 ```
 
 If you want to run tests at the same time:
 
 ```bash
-./gradlew clean build -Pvaadin.productionMode -Pit
+./gradlew clean build -Pit
 ```
 
 
@@ -71,13 +71,13 @@ Usually the CI images will not have node.js+npm available. Luckily Vaadin will d
 To build your app for production in CI, just run:
 
 ```bash
-./gradlew clean build -Pvaadin.productionMode
+./gradlew clean build
 ```
 
 To build and run ITs at the same time run:
 
 ```bash
-./gradlew clean build -Pvaadin.productionMode -Pit -Dcom.vaadin.testbench.Parameters.headless=true
+./gradlew clean build -Pit -Dcom.vaadin.testbench.Parameters.headless=true
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,17 +30,21 @@ gretty {
 
 // The following pnpmEnable = false is not needed as npm is used by default,
 // this is just an example of how to configure the Gradle Vaadin Plugin:
-// for more configuraion options please see: https://vaadin.com/docs/latest/guide/start/gradle/#all-options
+// for more configuration options please see: https://vaadin.com/docs/latest/guide/start/gradle/#all-options
 vaadin {
     pnpmEnable = false
+    productionMode = gradle.startParameter.taskNames.any {
+        ["build"].contains(it)
+    }
 }
 
 dependencies {
     implementation enforcedPlatform("com.vaadin:vaadin-bom:$vaadinVersion")
 
     // Vaadin
-    implementation("com.vaadin:vaadin-core") {
-        exclude group: 'com.vaadin', module: 'hilla-dev'
+    implementation("com.vaadin:vaadin-core")
+    if (gradle.startParameter.taskNames.contains('appRun')) {
+        implementation("com.vaadin:vaadin-dev")
     }
 
     // logging

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-vaadinVersion=25.0.0-beta1
+vaadinVersion=25.0-SNAPSHOT
 hilla.active=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-vaadinVersion=25.0-SNAPSHOT
+vaadinVersion=25.0.0-beta6
 hilla.active=false


### PR DESCRIPTION
Includes `vaadin-dev` only when run with Gretty's `appRun` task. `build` task enables `productionMode` automatically.

PartOf: vaadin/flow#22715