### PR TITLE
chore: Add JNA for dev mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     // Vaadin
     implementation("com.vaadin:vaadin-core")
     if (gradle.startParameter.taskNames.contains('appRun')) {
+        implementation("net.java.dev.jna:jna:5.18.1")
         implementation("com.vaadin:vaadin-dev")
     }
 


### PR DESCRIPTION
Otherwise jetty/gretty throws NoClassDefFoundException for JNA class and dev-tools don't work.