### PR TITLE
Bump Vaadin version to 25.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-vaadinVersion=25.0.0-beta9
+vaadinVersion=25.0.0
 hilla.active=false


### PR DESCRIPTION
## Summary
- Updates Vaadin version from 25.0.0-beta9 to 25.0.0 GA

## Test plan
- Build completes successfully with new version