### PR TITLE
Downgrade Gradle 9.0 to 8.12 for gretty compatibility

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Gretty (including 5.0.1) uses the `archivePath` property which was removed in Gradle 9
- This causes `jettyStartWar` to fail with: `Could not get unknown property 'archivePath' for task ':war'`
- Downgrade to Gradle 8.12 until gretty adds Gradle 9 support

## Test plan
- [ ] Run `./gradlew jettyStartWar` and verify prod mode works
- [ ] Run `./gradlew jettyStart` and verify dev mode still works