### PR TITLE
Update README to use Jetty 12 EE10 runner for production WAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ If you want to run tests at the same time:
 
 That will build this app in production mode as a WAR archive; please find the
 WAR file in `build/libs/base-starter-gradle.war`. You can run the WAR file
-by using [Jetty Runner](https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-runner):
+by using [Jetty EE10 Runner](https://mvnrepository.com/artifact/org.eclipse.jetty.ee10/jetty-ee10-runner)
+(Vaadin 25 requires Jetty 12+ for Jakarta Servlet 6 support):
 
 ```bash
 cd build/libs/
-wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/11.0.15/jetty-runner-11.0.15.jar
-java -jar jetty-runner-11.0.15.jar base-starter-gradle.war
+wget https://repo1.maven.org/maven2/org/eclipse/jetty/ee10/jetty-ee10-runner/12.0.34/jetty-ee10-runner-12.0.34.jar
+java -jar jetty-ee10-runner-12.0.34.jar base-starter-gradle.war
 ```
 
 Now you can open the [http://localhost:8080](http://localhost:8080) with your browser.


### PR DESCRIPTION
## Summary

- Replace `jetty-runner-11.0.15.jar` (Jetty 11) with `jetty-ee10-runner-12.0.34.jar` (Jetty 12)
- Vaadin 25 requires Jakarta Servlet 6 (`jakarta.servlet`), available in Jetty 12+
- Jetty 11 uses `javax.servlet` and is incompatible with Vaadin 25

## Context

- Related: [https://github.com/vaadin/flow/issues/24028 (MalformedURLException when loading style sheets)](https://github.com/vaadin/flow/issues/24204)
